### PR TITLE
FontTexture change

### DIFF
--- a/src/engine/core/graph/hud/FontTexture.java
+++ b/src/engine/core/graph/hud/FontTexture.java
@@ -108,7 +108,6 @@ public class FontTexture{
 		try(ByteArrayOutputStream out = new ByteArrayOutputStream()){
 			
 			ImageIO.write(img, IMAGE_FORMAT, out);
-			ImageIO.write(img, IMAGE_FORMAT, new java.io.File("D://Temp.png"));
 			out.flush();
 			is = new ByteArrayInputStream(out.toByteArray());
 		}


### PR DESCRIPTION
Removed line which writes a new png image containing the font atlas in the D: drive. This may cause some problems on system where such a drive does not exist.
